### PR TITLE
Add (group) uploader based filtering

### DIFF
--- a/src/ComicK/ComicK.ts
+++ b/src/ComicK/ComicK.ts
@@ -32,7 +32,8 @@ import {
 import { 
     chapterSettings,
     languageSettings,
-    resetSettings 
+    resetSettings, 
+    uploadersSettings
 } from './ComicKSettings'
 
 import { CMLanguages } from './ComicKHelper'
@@ -42,7 +43,7 @@ const COMICK_API = 'https://api.comick.fun'
 const SEARCH_PAGE_LIMIT = 100
 
 export const ComicKInfo: SourceInfo = {
-    version: '2.0.2',
+    version: '2.1.2',
     name: 'ComicK',
     icon: 'icon.png',
     author: 'xOnlyFadi',
@@ -89,7 +90,8 @@ export class ComicK implements MangaProviding, ChapterProviding, SearchResultsPr
             rows: async () => [
                 languageSettings(this.stateManager),
                 chapterSettings(this.stateManager),
-                resetSettings(this.stateManager)
+                uploadersSettings(this.stateManager),
+                resetSettings(this.stateManager),
             ]
         }))
     }
@@ -123,7 +125,7 @@ export class ComicK implements MangaProviding, ChapterProviding, SearchResultsPr
         let json = null
         do {
             json = await this.createChapterRequest(mangaId, page)
-            chapters.push(...parseChapters(json, { show_title: showTitle, show_volume: showVol }))
+            chapters.push(...(await parseChapters(json, { show_title: showTitle, show_volume: showVol }, this.stateManager)))
             page += 1
         } while (json.chapters.length === SEARCH_PAGE_LIMIT)
 

--- a/src/ComicK/ComicK.ts
+++ b/src/ComicK/ComicK.ts
@@ -43,7 +43,7 @@ const COMICK_API = 'https://api.comick.fun'
 const SEARCH_PAGE_LIMIT = 100
 
 export const ComicKInfo: SourceInfo = {
-    version: '2.1.2',
+    version: '2.1.0',
     name: 'ComicK',
     icon: 'icon.png',
     author: 'xOnlyFadi',

--- a/src/ComicK/ComicKSettings.ts
+++ b/src/ComicK/ComicKSettings.ts
@@ -79,6 +79,170 @@ export const languageSettings = (stateManager: SourceStateManager): DUINavigatio
     })
 }
 
+
+const getUploaders = async (stateManager: SourceStateManager): Promise<Uploader[]> => {
+    return (await stateManager.retrieve('uploaders') ?? [])
+}
+const getSelectedUploaders = async (stateManager: SourceStateManager): Promise<Uploader[]> => {
+    return (await getUploaders(stateManager) ?? []).filter((uploader: any) => uploader.selected).map((uploader: any) => uploader.value)
+}
+
+export type Uploader = {
+    selected: boolean
+    value: string
+}
+
+export const uploadersSettings = (stateManager: SourceStateManager): DUINavigationButton => {
+    return App.createDUINavigationButton({
+        id: 'uploaders_settings',
+        label: 'Uploaders Settings',
+        form: App.createDUIForm({
+            sections: async () => [
+                App.createDUISection({
+                    id: 'select_uploaders',
+                    footer: 'Select which uploaders you want or not want to see when browsing.\nBy default, this feature is disabled, but when enabled and an uploader is selected, it will be excluded from the chapter lists.\nYou can change this behavior by toggling the switch below.',
+                    isHidden: false,
+                    rows: async () => [
+                        App.createDUISwitch({
+                            id: 'toggle_uploaders_filtering',
+                            label: 'Toggle uploaders filtering',
+                            value: App.createDUIBinding({
+                                get: async () => await stateManager.retrieve('uploaders_toggled') ?? false,
+                                set: async (newValue: boolean) => await stateManager.store('uploaders_toggled', newValue)
+                            }),
+                        }),
+                        App.createDUISelect({
+                            id: 'uploaders',
+                            label: 'Uploaders',
+                            options: (await getUploaders(stateManager)).map((uploader: Uploader) => uploader.value),
+                            labelResolver: async (option) => {
+                                return option
+                            },
+                            value: App.createDUIBinding({
+                                get: async () => await getSelectedUploaders(stateManager),
+                                set: async (selectedUploaders: string[]) => {
+                                    const uploaders: Uploader[] = await getUploaders(stateManager)
+
+                                    uploaders.forEach((uploader: Uploader) => {
+                                        uploader.selected = false
+                                    })
+
+                                    selectedUploaders.forEach((selectedUploader: string) => {
+                                        uploaders.forEach((uploader: Uploader) => {
+                                            if (uploader.value === selectedUploader) {
+                                                uploader.selected = true
+                                            }
+                                        })
+                                    })
+                                    
+                                    await stateManager.store('uploaders', uploaders)
+                                }
+                            }),
+                            allowsMultiselect: true,
+                        }),
+                        App.createDUISwitch({
+                            id: 'uploaders_switch',
+                            label: 'Blacklist / Whitelist Uploaders',
+                            value: App.createDUIBinding({
+                                get: async () => await stateManager.retrieve('uploaders_whitelisted') ?? false,
+                                set: async (newValue: boolean) => await stateManager.store('uploaders_whitelisted', newValue)
+                            }),
+                        }),
+                        App.createDUISwitch({
+                            id: 'toggle_uploaders_filtering_aggressiveness',
+                            label: 'Toggle aggressive filtering',
+                            value: App.createDUIBinding({
+                                // default to true if no value is set
+                                get: async () => {
+                                    const value = await stateManager.retrieve('aggressive_uploaders_filtering')
+                                    
+
+                                    if (value !== false) {
+                                        return true
+                                    }
+
+                                    return false
+                                },
+                                set: async (newValue: boolean) => await stateManager.store('aggressive_uploaders_filtering', newValue)
+                            }),
+                        }),
+                        App.createDUISwitch({
+                            id: 'strict_name_matching',
+                            label: 'Strict uploader name matching',
+                            value: App.createDUIBinding({
+                                get: async () => await stateManager.retrieve('strict_name_matching') ?? false,
+                                set: async (newValue: boolean) => await stateManager.store('strict_name_matching', newValue)
+                            }),
+                        })
+                    ]
+                }),
+                App.createDUISection({
+                    id: 'modify_uploaders',
+                    footer: 'Edit list of uploaders.',
+                    isHidden: false,
+                    rows: async () => [
+                        App.createDUIInputField({
+                            id: 'uploader',
+                            label: 'Uploader',
+                            value: App.createDUIBinding({
+                                get: async () => '',
+                                set: async (newValue: string) => await stateManager.store('uploader', newValue)
+                            }),
+                        }),
+                        App.createDUIButton({
+                            id: 'add_uploader',
+                            label: 'Add Uploader',
+                            onTap: async () => {
+                                const targetUploader: string = await stateManager.retrieve('uploader') ?? ''
+
+                                if (targetUploader === '') {
+                                    throw new Error('Uploader cannot be empty!')
+                                }
+
+                                const uploaders: Uploader[] = await getUploaders(stateManager)
+
+                                if (uploaders.filter((uploader: Uploader) => uploader.value === targetUploader).length > 0) {
+                                    console.log(`Uploader '${targetUploader}' already exists in list. (${uploaders.map((uploader: Uploader) => uploader.value).join(', ')})`)
+                                    throw new Error('Uploader already exists in your list!')
+                                } else {
+                                    uploaders.push({
+                                        selected: false,
+                                        value: targetUploader
+                                    })
+                                    await stateManager.store('uploaders', uploaders)
+                                }
+                            }
+                        }),
+                        App.createDUIButton({
+                            id: 'remove_uploader',
+                            label: 'Remove Uploader',
+                            onTap: async () => {
+                                const targetUploader: string = await stateManager.retrieve('uploader') ?? ''
+
+                                if (targetUploader === '') {
+                                    throw new Error('Uploader cannot be empty!')
+                                }
+
+                                const uploaders: Uploader[] = await getUploaders(stateManager)
+                                uploaders.forEach((uploader: Uploader) => {
+                                    if (uploader.value === targetUploader) {
+                                        const index = uploaders.indexOf(uploader)
+                                        
+                                        if (index > -1) {
+                                            uploaders.splice(index, 1)
+                                        }
+                                    }
+                                })
+                                await stateManager.store('uploaders', uploaders)
+                            }
+                        }),
+                    ]
+                })
+            ]
+        })
+    })
+}
+
 export const resetSettings = (stateManager: SourceStateManager): DUIButton => {
     return App.createDUIButton({
         id: 'reset',
@@ -87,7 +251,13 @@ export const resetSettings = (stateManager: SourceStateManager): DUIButton => {
             stateManager.store('show_volume_number', null),
             stateManager.store('show_title', null),
             stateManager.store('languages', null),
-            stateManager.store('language_home_filter', null)
+            stateManager.store('language_home_filter', null),
+            stateManager.store('uploaders', null),
+            stateManager.store('uploaders_whitelisted', null),
+            stateManager.store('aggressive_uploaders_filtering', null),
+            stateManager.store('uploaders_toggled', null),
+            stateManager.store('uploader', null),
+            stateManager.store('strict_name_matching', null)
         }
     })
 }

--- a/src/ComicK/ComicKSettings.ts
+++ b/src/ComicK/ComicKSettings.ts
@@ -100,7 +100,7 @@ export const uploadersSettings = (stateManager: SourceStateManager): DUINavigati
             sections: async () => [
                 App.createDUISection({
                     id: 'select_uploaders',
-                    footer: 'Select which uploaders you want or not want to see when browsing.\nBy default, this feature is disabled, but when enabled and an uploader is selected, it will be excluded from the chapter lists.\nYou can change this behavior by toggling the switch below.',
+                    footer: 'Select which uploaders you want or not want to see when browsing.\nBy default, this feature is disabled, but when enabled and an uploader is selected, it will be excluded from the chapter lists.\nYou can change this behavior by toggling the corresponding switch above.',
                     isHidden: false,
                     rows: async () => [
                         App.createDUISwitch({


### PR DESCRIPTION
New setting added in source settings menu that allows the end user to refine from which group/uploader they want to see the chapters from.

The feature includes:
- Turning it on/off
- Adding uploader/group names to a list
- Switching between whitelist or blacklist filtering
- Toggleable aggressive filtering*
- Strict name matching**

* By default turned on, for whitelist it will only allow chapters by the list of groups that are in the whitelist, meaning that if multiple groups worked on a single chapter together, they both have to be in the whitelist for that chapter to appear.
For blacklist, it will hide all chapters that a group has worked on, that is in the blacklist. Even if multiple groups worked on it and the other group is not in the blacklist.
** When turned on, it will only match with the same name (e.g. foo and Foo will not match), while when turned off, it will match anything that looks like it (e.g. foo and FoObAr will match, as everything is brought to lowercase and foo is contained inside "foobar")