### PR TITLE
Comick | Automatic Uploader Filtering

### DIFF
--- a/src/ComicK/ComicK.ts
+++ b/src/ComicK/ComicK.ts
@@ -122,7 +122,7 @@ export class ComicK implements MangaProviding, ChapterProviding, SearchResultsPr
     async getChapters(mangaId: string): Promise<Chapter[]> {
         const showTitle: boolean = await this.stateManager.retrieve('show_title') ?? false
         const showVol: boolean = await this.stateManager.retrieve('show_volume_number') ?? false
-        const autofilterChaptersByScore: boolean = await this.stateManager.retrieve('filter_chapters_by_score') ?? false
+        const chapterScoreFiltering: boolean = await this.stateManager.retrieve('chapter_score_filtering') ?? false
         const uploadersToggled: boolean = await this.stateManager.retrieve('uploaders_toggled') ?? false
         const uploadersWhitelisted: boolean = await this.stateManager.retrieve('uploaders_whitelisted') ?? false
         const aggressiveUploadersFilter: boolean = await this.stateManager.retrieve('aggressive_uploaders_filtering') ?? false
@@ -139,7 +139,7 @@ export class ComicK implements MangaProviding, ChapterProviding, SearchResultsPr
             data,
             showTitle,
             showVol,
-            autofilterChaptersByScore,
+            chapterScoreFiltering,
             uploadersToggled,
             uploadersWhitelisted,
             aggressiveUploadersFilter,
@@ -159,7 +159,7 @@ export class ComicK implements MangaProviding, ChapterProviding, SearchResultsPr
                 data,
                 showTitle,
                 showVol,
-                autofilterChaptersByScore,
+                chapterScoreFiltering,
                 uploadersToggled,
                 uploadersWhitelisted,
                 aggressiveUploadersFilter,

--- a/src/ComicK/ComicK.ts
+++ b/src/ComicK/ComicK.ts
@@ -45,7 +45,7 @@ const COMICK_API = 'https://api.comick.fun'
 const LIMIT = 300
 
 export const ComicKInfo: SourceInfo = {
-    version: '2.1.3',
+    version: '2.2.0',
     name: 'ComicK',
     icon: 'icon.png',
     author: 'xOnlyFadi',

--- a/src/ComicK/ComicK.ts
+++ b/src/ComicK/ComicK.ts
@@ -122,7 +122,7 @@ export class ComicK implements MangaProviding, ChapterProviding, SearchResultsPr
     async getChapters(mangaId: string): Promise<Chapter[]> {
         const showTitle: boolean = await this.stateManager.retrieve('show_title') ?? false
         const showVol: boolean = await this.stateManager.retrieve('show_volume_number') ?? false
-        const uploadersAutoFiltering: boolean = await this.stateManager.retrieve('uploaders_auto_filtering') ?? false
+        const autofilterChaptersByScore: boolean = await this.stateManager.retrieve('filter_chapters_by_score') ?? false
         const uploadersToggled: boolean = await this.stateManager.retrieve('uploaders_toggled') ?? false
         const uploadersWhitelisted: boolean = await this.stateManager.retrieve('uploaders_whitelisted') ?? false
         const aggressiveUploadersFilter: boolean = await this.stateManager.retrieve('aggressive_uploaders_filtering') ?? false
@@ -139,7 +139,7 @@ export class ComicK implements MangaProviding, ChapterProviding, SearchResultsPr
             data,
             showTitle,
             showVol,
-            uploadersAutoFiltering,
+            autofilterChaptersByScore,
             uploadersToggled,
             uploadersWhitelisted,
             aggressiveUploadersFilter,
@@ -159,7 +159,7 @@ export class ComicK implements MangaProviding, ChapterProviding, SearchResultsPr
                 data,
                 showTitle,
                 showVol,
-                uploadersAutoFiltering,
+                autofilterChaptersByScore,
                 uploadersToggled,
                 uploadersWhitelisted,
                 aggressiveUploadersFilter,

--- a/src/ComicK/ComicK.ts
+++ b/src/ComicK/ComicK.ts
@@ -122,6 +122,7 @@ export class ComicK implements MangaProviding, ChapterProviding, SearchResultsPr
     async getChapters(mangaId: string): Promise<Chapter[]> {
         const showTitle: boolean = await this.stateManager.retrieve('show_title') ?? false
         const showVol: boolean = await this.stateManager.retrieve('show_volume_number') ?? false
+        const uploadersAutoFiltering: boolean = await this.stateManager.retrieve('uploaders_auto_filtering') ?? false
         const uploadersToggled: boolean = await this.stateManager.retrieve('uploaders_toggled') ?? false
         const uploadersWhitelisted: boolean = await this.stateManager.retrieve('uploaders_whitelisted') ?? false
         const aggressiveUploadersFilter: boolean = await this.stateManager.retrieve('aggressive_uploaders_filtering') ?? false
@@ -138,6 +139,7 @@ export class ComicK implements MangaProviding, ChapterProviding, SearchResultsPr
             data,
             showTitle,
             showVol,
+            uploadersAutoFiltering,
             uploadersToggled,
             uploadersWhitelisted,
             aggressiveUploadersFilter,
@@ -157,6 +159,7 @@ export class ComicK implements MangaProviding, ChapterProviding, SearchResultsPr
                 data,
                 showTitle,
                 showVol,
+                uploadersAutoFiltering,
                 uploadersToggled,
                 uploadersWhitelisted,
                 aggressiveUploadersFilter,

--- a/src/ComicK/ComicKHelper.ts
+++ b/src/ComicK/ComicKHelper.ts
@@ -30,7 +30,7 @@ interface MDGroups {
     title: string;
 }
 
-interface ChapterData {
+export interface ChapterData {
     id: number;
     chap: string;
     title: null | string;

--- a/src/ComicK/ComicKParser.ts
+++ b/src/ComicK/ComicKParser.ts
@@ -118,7 +118,7 @@ export const parseChapters = (
     strictNameMatching: boolean,
     uploaders: string[]
 ): void => {
-    var filteredChapters = data.chapters
+    let filteredChapters = data.chapters
     if (uploadersAutoFiltering) {
         filteredChapters = filterUploadersByScore(data.chapters)
     } else if (uploadersToggled && uploaders.length > 0) {

--- a/src/ComicK/ComicKParser.ts
+++ b/src/ComicK/ComicKParser.ts
@@ -163,19 +163,19 @@ export const parseChapters = (
 }
 
 const filterChaptersByScore = (chapterData: ChapterData[], chapters: ChapterData[]): void => {
-    const chapterMap = new Map<number, { score: number, chapterIndex: number }>()
-    for (const [index, chapter] of chapterData.entries()) {
+    const chapterMap = new Map<number, { score: number, chapter: ChapterData }>()
+    for (const chapter of chapterData) {
         const chapNum = Number(chapter?.chap)
         const chapterScore = chapter.up_count - chapter.down_count
         if (chapterMap.has(chapNum)) {
             if (chapterScore > chapterMap.get(chapNum)!.score) {
-                chapterMap.set(chapNum, { score: chapterScore, chapterIndex: index })
+                chapterMap.set(chapNum, { score: chapterScore, chapter: chapter })
             }
         } else {
-            chapterMap.set(chapNum, { score: chapterScore, chapterIndex: index })
+            chapterMap.set(chapNum, { score: chapterScore, chapter: chapter })
         }
     }
-    chapters.push(...Array.from(chapterMap.values(), ((mapValue) => chapterData[mapValue.chapterIndex]!)))
+    chapters.push(...Array.from(chapterMap.values(), ((mapValue) => mapValue.chapter)))
 }
 
 const filterChaptersByUploaderList = (

--- a/src/ComicK/ComicKParser.ts
+++ b/src/ComicK/ComicKParser.ts
@@ -175,7 +175,9 @@ const filterChaptersByScore = (chapterData: ChapterData[], chapters: ChapterData
             chapterMap.set(chapNum, { score: chapterScore, chapter: chapter })
         }
     }
-    chapters.push(...Array.from(chapterMap.values(), ((mapValue) => mapValue.chapter)))
+    chapterMap.forEach(mapValue => {
+        chapters.push(mapValue.chapter)
+    })
 }
 
 const filterChaptersByUploaderList = (
@@ -186,7 +188,7 @@ const filterChaptersByUploaderList = (
     strictNameMatching: boolean,
     uploaders: string[]
 ): void => {
-    chapters.push(...chapterData.filter((chapter) => {
+    chapterData.filter((chapter) => {
         const groups = []
         if (chapter?.group_name) {
             for (const group of chapter.group_name) {
@@ -220,7 +222,9 @@ const filterChaptersByUploaderList = (
             }
         }
         return true
-    }))
+    }).forEach(chapter => {
+        chapters.push(chapter)
+    })
 }
 
 export const parseChapterDetails = (data: PageList, mangaId: string, chapterId: string): ChapterDetails => {

--- a/src/ComicK/ComicKParser.ts
+++ b/src/ComicK/ComicKParser.ts
@@ -163,19 +163,19 @@ export const parseChapters = (
 }
 
 const filterChaptersByScore = (chapterData: ChapterData[], chapters: ChapterData[]): void => {
-    const chapterMap = new Map<number, { score: number, chapter: ChapterData }>()
-    for (const chapter of chapterData) {
+    const chapterMap = new Map<number, { score: number, chapterIndex: number }>()
+    for (const [index, chapter] of chapterData.entries()) {
         const chapNum = Number(chapter?.chap)
         const chapterScore = chapter.up_count - chapter.down_count
         if (chapterMap.has(chapNum)) {
             if (chapterScore > chapterMap.get(chapNum)!.score) {
-                chapterMap.set(chapNum, { score: chapterScore, chapter: chapter })
+                chapterMap.set(chapNum, { score: chapterScore, chapterIndex: index })
             }
         } else {
-            chapterMap.set(chapNum, { score: chapterScore, chapter: chapter })
+            chapterMap.set(chapNum, { score: chapterScore, chapterIndex: index })
         }
     }
-    chapters.push(...Array.from(chapterMap.values(), ((mapValue) => mapValue.chapter)))
+    chapters.push(...Array.from(chapterMap.values(), ((mapValue) => chapterData[mapValue.chapterIndex]!)))
 }
 
 const filterChaptersByUploaderList = (

--- a/src/ComicK/ComicKParser.ts
+++ b/src/ComicK/ComicKParser.ts
@@ -111,7 +111,7 @@ export const parseChapters = (
     data: ChapterList,
     showTitle: boolean,
     showVol: boolean,
-    autofilterChaptersByScore: boolean,
+    chapterScoreFiltering: boolean,
     uploadersToggled: boolean,
     uploadersWhitelisted: boolean,
     aggressiveUploadersFilter: boolean,
@@ -119,7 +119,8 @@ export const parseChapters = (
     uploaders: string[]
 ): void => {
     const chaptersData: ChapterData[] = []
-    if (autofilterChaptersByScore) {
+
+    if (chapterScoreFiltering) {
         filterChaptersByScore(data.chapters, chaptersData)
     } else if (uploadersToggled && uploaders.length > 0) {
         filterChaptersByUploaderList(
@@ -133,6 +134,7 @@ export const parseChapters = (
     } else {
         chaptersData.push(...data.chapters)
     }
+
     for (const chapter of chaptersData) {
         const id = chapter?.hid ?? ''
         const chap = chapter?.chap
@@ -160,9 +162,9 @@ export const parseChapters = (
     }
 }
 
-const filterChaptersByScore = (unfilteredChapters: ChapterData[], chapters: ChapterData[]): void => {
+const filterChaptersByScore = (chapterData: ChapterData[], chapters: ChapterData[]): void => {
     const chapterMap = new Map<number, { score: number, chapter: ChapterData }>()
-    for (const chapter of unfilteredChapters) {
+    for (const chapter of chapterData) {
         const chapNum = Number(chapter?.chap)
         const chapterScore = chapter.up_count - chapter.down_count
         if (chapterMap.has(chapNum)) {
@@ -177,14 +179,14 @@ const filterChaptersByScore = (unfilteredChapters: ChapterData[], chapters: Chap
 }
 
 const filterChaptersByUploaderList = (
-    unfilteredChapters: ChapterData[],
+    chapterData: ChapterData[],
     chapters: ChapterData[],
     uploadersWhitelisted: boolean,
     aggressiveUploadersFilter: boolean,
     strictNameMatching: boolean,
     uploaders: string[]
 ): void => {
-    chapters.push(...unfilteredChapters.filter((chapter) => {
+    chapters.push(...chapterData.filter((chapter) => {
         const groups = []
         if (chapter?.group_name) {
             for (const group of chapter.group_name) {

--- a/src/ComicK/ComicKParser.ts
+++ b/src/ComicK/ComicKParser.ts
@@ -118,86 +118,96 @@ export const parseChapters = (
     strictNameMatching: boolean,
     uploaders: string[]
 ): void => {
+    var filteredChapters = data.chapters
     if (uploadersAutoFiltering) {
-        const _chapters = new Map<number, { score: number, chapter: ChapterData }>()
-        for (const chapter of data.chapters) {
-            const chapNum = Number(chapter?.chap)
-            const chapterScore = chapter.up_count - chapter.down_count
-            if (_chapters.has(chapNum)) {
-                if (chapterScore > _chapters.get(chapNum)!.score) {
-                    _chapters.set(chapNum, { score: chapterScore, chapter: chapter })
-                }
-            } else {
-                _chapters.set(chapNum, { score: chapterScore, chapter: chapter })
-            }
-        }
-        for (const value of _chapters.values()) {
-            chapters.push(bridgeChapterData(value.chapter, showTitle, showVol))
-        }
-    } else {
-        for (const chapter of data.chapters) {
-            const groups = []
-            if (chapter?.group_name) {
-                for (const group of chapter.group_name) {
-                    groups.push(group)
-                }
-            }
+        filteredChapters = filterUploadersByScore(data.chapters)
+    } else if (uploadersToggled && uploaders.length > 0) {
+        filteredChapters = filterUploadersByList(data.chapters, uploadersWhitelisted, aggressiveUploadersFilter, strictNameMatching, uploaders)
+    }
+    for (const chapter of filteredChapters) {
+        const id = chapter?.hid ?? ''
+        const chap = chapter?.chap
+        const vol = chapter?.vol
 
-            if (uploadersToggled && uploaders.length > 0) {
-                if (aggressiveUploadersFilter) {
-                    if (uploadersWhitelisted) {
-                        // We check if that if the chapter does not have any of the uploaders in the list, we don't push it (we only allow chapters that have all the uploaders in the whitelist)
-                        if (!groups.every(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
-                            continue
-                        }
-                    } else {
-                        // We check if that if the chapter has even a single uploader in the list, we don't push it (we only allow chapters that have none of the uploaders in the blacklist)
-                        if (groups.some(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
-                            continue
-                        }
-                    }
-                } else {
-                    if (uploadersWhitelisted) {
-                        // We check if that if the chapter does not have any of the uploaders in the list, we don't push it (we only allow chapters that have all the uploaders in the whitelist)
-                        if (!groups.some(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
-                            continue
-                        }
-                    } else {
-                        // Only if all the uploaders are in the blacklist, we don't push the chapter
-                        if (groups.every(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
-                            continue
-                        }
-                    }
-                }
+        const chapNum = Number(chap)
+        const volume = Number(vol)
+
+        const groups = []
+        if (chapter?.group_name) {
+            for (const group of chapter.group_name) {
+                groups.push(group)
             }
-            chapters.push(bridgeChapterData(chapter, showTitle, showVol))
         }
+
+        chapters.push(App.createChapter({
+            id,
+            name: `Chapter ${chap}${showTitle ? chapter?.title ? `: ${chapter?.title}` : '' : ''}`,
+            chapNum: chapNum,
+            volume: showVol ? !isNaN(volume) ? volume : undefined : undefined,
+            time: new Date(chapter?.created_at),
+            group: groups?.length !== 0 ? groups?.join(',') : '',
+            langCode: CMLanguages?.getEmoji(chapter?.lang)
+        }))
     }
 }
 
-export const bridgeChapterData = (chapter: ChapterData, showTitle: boolean, showVol: boolean): Chapter => {
-    const id = chapter?.hid ?? ''
-    const chap = chapter?.chap
-    const vol = chapter?.vol
-
-    const chapNum = Number(chap)
-    const volume = Number(vol)
-
-    const groups = []
-    if (chapter?.group_name) {
-        for (const group of chapter.group_name) {
-            groups.push(group)
+const filterUploadersByScore = (chapters: ChapterData[]): ChapterData[] => {
+    const chapterMap = new Map<number, { score: number, chapter: ChapterData }>()
+        for (const chapter of chapters) {
+            const chapNum = Number(chapter?.chap)
+            const chapterScore = chapter.up_count - chapter.down_count
+            if (chapterMap.has(chapNum)) {
+                if (chapterScore > chapterMap.get(chapNum)!.score) {
+                    chapterMap.set(chapNum, { score: chapterScore, chapter: chapter })
+                }
+            } else {
+                chapterMap.set(chapNum, { score: chapterScore, chapter: chapter })
+            }
         }
-    }
+        return Array.from(chapterMap.values(), ((mapValue) => mapValue.chapter))
+}
 
-    return App.createChapter({
-        id,
-        name: `Chapter ${chap}${showTitle ? chapter?.title ? `: ${chapter?.title}` : '' : ''}`,
-        chapNum: chapNum,
-        volume: showVol ? !isNaN(volume) ? volume : undefined : undefined,
-        time: new Date(chapter?.created_at),
-        group: groups?.length !== 0 ? groups?.join(',') : '',
-        langCode: CMLanguages?.getEmoji(chapter?.lang)
+const filterUploadersByList = (
+    chapters: ChapterData[],
+    uploadersWhitelisted: boolean,
+    aggressiveUploadersFilter: boolean,
+    strictNameMatching: boolean,
+    uploaders: string[]
+): ChapterData[] => {
+    return chapters.filter((chapter) => {
+        const groups = []
+        if (chapter?.group_name) {
+            for (const group of chapter.group_name) {
+                groups.push(group)
+            }
+        }
+
+        if (aggressiveUploadersFilter) {
+            if (uploadersWhitelisted) {
+                // We check if that if the chapter does not have any of the uploaders in the list, we don't push it (we only allow chapters that have all the uploaders in the whitelist)
+                if (!groups.every(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
+                    return false
+                }
+            } else {
+                // We check if that if the chapter has even a single uploader in the list, we don't push it (we only allow chapters that have none of the uploaders in the blacklist)
+                if (groups.some(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
+                    return false
+                }
+            }
+        } else {
+            if (uploadersWhitelisted) {
+                // We check if that if the chapter does not have any of the uploaders in the list, we don't push it (we only allow chapters that have all the uploaders in the whitelist)
+                if (!groups.some(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
+                    return false
+                }
+            } else {
+                // Only if all the uploaders are in the blacklist, we don't push the chapter
+                if (groups.every(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
+                    return false
+                }
+            }
+        }
+        return true
     })
 }
 

--- a/src/ComicK/ComicKParser.ts
+++ b/src/ComicK/ComicKParser.ts
@@ -185,24 +185,24 @@ const filterUploadersByList = (
         if (aggressiveUploadersFilter) {
             if (uploadersWhitelisted) {
                 // We check if that if the chapter does not have any of the uploaders in the list, we don't push it (we only allow chapters that have all the uploaders in the whitelist)
-                if (!groups.every(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
+                if (!groups.every(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && group.toLowerCase().includes(uploader.toLowerCase())))))) {
                     return false
                 }
             } else {
                 // We check if that if the chapter has even a single uploader in the list, we don't push it (we only allow chapters that have none of the uploaders in the blacklist)
-                if (groups.some(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
+                if (groups.some(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && group.toLowerCase().includes(uploader.toLowerCase())))))) {
                     return false
                 }
             }
         } else {
             if (uploadersWhitelisted) {
                 // We check if that if the chapter does not have any of the uploaders in the list, we don't push it (we only allow chapters that have all the uploaders in the whitelist)
-                if (!groups.some(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
+                if (!groups.some(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && group.toLowerCase().includes(uploader.toLowerCase())))))) {
                     return false
                 }
             } else {
                 // Only if all the uploaders are in the blacklist, we don't push the chapter
-                if (groups.every(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && uploader.toLowerCase().includes(group.toLowerCase())))))) {
+                if (groups.every(group => uploaders.some(uploader => (strictNameMatching && (uploader === group) || (!strictNameMatching && group.toLowerCase().includes(uploader.toLowerCase())))))) {
                     return false
                 }
             }

--- a/src/ComicK/ComicKParser.ts
+++ b/src/ComicK/ComicKParser.ts
@@ -132,7 +132,9 @@ export const parseChapters = (
             uploaders
         )
     } else {
-        chaptersData.push(...data.chapters)
+        data.chapters.forEach(chapter => {
+            chaptersData.push(chapter)
+        })
     }
 
     for (const chapter of chaptersData) {

--- a/src/ComicK/ComicKSettings.ts
+++ b/src/ComicK/ComicKSettings.ts
@@ -52,8 +52,8 @@ const showVolumeNumber = async (stateManager: SourceStateManager): Promise<boole
     return (await stateManager.retrieve('show_volume_number') ?? false)
 }
 
-const getUploadersAutoFiltering = async (stateManager: SourceStateManager): Promise<boolean> => {
-    return (await stateManager.retrieve('uploaders_auto_filtering') ?? false)
+const getFilterChaptersByScore = async (stateManager: SourceStateManager): Promise<boolean> => {
+    return (await stateManager.retrieve('filter_chapters_by_score') ?? false)
 }
 
 export const chapterSettings = (stateManager: SourceStateManager): DUINavigationButton => {
@@ -141,16 +141,16 @@ export const uploadersSettings = (stateManager: SourceStateManager): DUINavigati
             sections: async () => [
                 App.createDUISection({
                     id: 'uploaders_autofiltering',
-                    header: 'Automatic Uploader Filtering',
+                    header: 'Autofilter uploaders by score',
                     footer: 'If enabled, automatically filter uploaders for each chapter\nFor each chapter number, only the uploader with the most upvotes will be displayed.\nIf this is enabled, the below settings will be completely ignored.',
                     isHidden: false,
                     rows: async () => [
                         App.createDUISwitch({
-                            id: 'toggle_uploaders_auto_filtering',
-                            label: 'Enable Uploader auto-filtering',
+                            id: 'toggle_filter_chapters_by_score',
+                            label: 'Enable score-based auto-filtering',
                             value: App.createDUIBinding({
-                                get: () => getUploadersAutoFiltering(stateManager),
-                                set: async (newValue: boolean) => await stateManager.store('uploaders_auto_filtering', newValue)
+                                get: () => getFilterChaptersByScore(stateManager),
+                                set: async (newValue: boolean) => await stateManager.store('filter_chapters_by_score', newValue)
                             })
                         })
                     ]
@@ -280,7 +280,7 @@ export const resetSettings = (stateManager: SourceStateManager): DUIButton => {
                 stateManager.store('show_title', null),
                 stateManager.store('languages', null),
                 stateManager.store('language_home_filter', null),
-                stateManager.store('uploaders_auto_filtering', null),
+                stateManager.store('filter_chapters_by_score', null),
                 stateManager.store('uploaders', null),
                 stateManager.store('uploaders_whitelisted', null),
                 stateManager.store('aggressive_uploaders_filtering', null),

--- a/src/ComicK/ComicKSettings.ts
+++ b/src/ComicK/ComicKSettings.ts
@@ -52,8 +52,8 @@ const showVolumeNumber = async (stateManager: SourceStateManager): Promise<boole
     return (await stateManager.retrieve('show_volume_number') ?? false)
 }
 
-const getFilterChaptersByScore = async (stateManager: SourceStateManager): Promise<boolean> => {
-    return (await stateManager.retrieve('filter_chapters_by_score') ?? false)
+const getChapterScoreFiltering = async (stateManager: SourceStateManager): Promise<boolean> => {
+    return (await stateManager.retrieve('chapter_score_filtering') ?? false)
 }
 
 export const chapterSettings = (stateManager: SourceStateManager): DUINavigationButton => {
@@ -140,25 +140,25 @@ export const uploadersSettings = (stateManager: SourceStateManager): DUINavigati
         form: App.createDUIForm({
             sections: async () => [
                 App.createDUISection({
-                    id: 'uploaders_autofiltering',
-                    header: 'Autofilter uploaders by score',
-                    footer: 'If enabled, automatically filter uploaders for each chapter\nFor each chapter number, only the uploader with the most upvotes will be displayed.\nIf this is enabled, the below settings will be disabled.\nDisable this setting to manually manage uploader filtering.',
+                    id: 'chapter_score_filtering',
+                    header: 'Filter Chapters by Score',
+                    footer: 'Show only the uploader with the most upvotes for each chapter.\nDisable to manually manage uploader filtering.',
                     isHidden: false,
                     rows: async () => [
                         App.createDUISwitch({
-                            id: 'toggle_filter_chapters_by_score',
-                            label: 'Enable score-based auto-filtering',
+                            id: 'toggle_chapter_score_filtering',
+                            label: 'Enable Chapter Score Filtering',
                             value: App.createDUIBinding({
-                                get: () => getFilterChaptersByScore(stateManager),
-                                set: async (newValue: boolean) => await stateManager.store('filter_chapters_by_score', newValue)
+                                get: () => getChapterScoreFiltering(stateManager),
+                                set: async (newValue: boolean) => await stateManager.store('chapter_score_filtering', newValue)
                             })
                         })
                     ]
-                }),
+                }),                
                 App.createDUISection({
                     id: 'modify_uploaders',
                     header: 'Uploaders',
-                    isHidden: await getFilterChaptersByScore(stateManager),
+                    isHidden: await getChapterScoreFiltering(stateManager),
                     rows: async () => [
                         App.createDUISelect({
                             id: 'uploaders',
@@ -228,7 +228,7 @@ export const uploadersSettings = (stateManager: SourceStateManager): DUINavigati
                     id: 'select_uploaders',
                     header: 'Filtering Settings',
                     footer: 'Filter Uploaders by name.\nBy default, selected uploaders are excluded from chapter lists (blacklist mode).',
-                    isHidden: await getFilterChaptersByScore(stateManager),
+                    isHidden: await getChapterScoreFiltering(stateManager),
                     rows: async () => [
                         App.createDUISwitch({
                             id: 'toggle_uploaders_filtering',
@@ -280,7 +280,7 @@ export const resetSettings = (stateManager: SourceStateManager): DUIButton => {
                 stateManager.store('show_title', null),
                 stateManager.store('languages', null),
                 stateManager.store('language_home_filter', null),
-                stateManager.store('filter_chapters_by_score', null),
+                stateManager.store('chapter_score_filtering', null),
                 stateManager.store('uploaders', null),
                 stateManager.store('uploaders_whitelisted', null),
                 stateManager.store('aggressive_uploaders_filtering', null),

--- a/src/ComicK/ComicKSettings.ts
+++ b/src/ComicK/ComicKSettings.ts
@@ -52,6 +52,10 @@ const showVolumeNumber = async (stateManager: SourceStateManager): Promise<boole
     return (await stateManager.retrieve('show_volume_number') ?? false)
 }
 
+const getUploadersAutoFiltering = async (stateManager: SourceStateManager): Promise<boolean> => {
+    return (await stateManager.retrieve('uploaders_auto_filtering') ?? false)
+}
+
 export const chapterSettings = (stateManager: SourceStateManager): DUINavigationButton => {
     return App.createDUINavigationButton({
         id: 'chapter_settings',
@@ -135,6 +139,22 @@ export const uploadersSettings = (stateManager: SourceStateManager): DUINavigati
         label: 'Uploaders Settings',
         form: App.createDUIForm({
             sections: async () => [
+                App.createDUISection({
+                    id: 'uploaders_autofiltering',
+                    header: 'Automatic Uploader Filtering',
+                    footer: 'If enabled, automatically filter uploaders for each chapter\nFor each chapter number, only the uploader with the most upvotes will be displayed.\nIf this is enabled, the below settings will be completely ignored.',
+                    isHidden: false,
+                    rows: async () => [
+                        App.createDUISwitch({
+                            id: 'toggle_uploaders_auto_filtering',
+                            label: 'Enable Uploader auto-filtering',
+                            value: App.createDUIBinding({
+                                get: () => getUploadersAutoFiltering(stateManager),
+                                set: async (newValue: boolean) => await stateManager.store('uploaders_auto_filtering', newValue)
+                            })
+                        })
+                    ]
+                }),
                 App.createDUISection({
                     id: 'modify_uploaders',
                     header: 'Uploaders',
@@ -260,6 +280,7 @@ export const resetSettings = (stateManager: SourceStateManager): DUIButton => {
                 stateManager.store('show_title', null),
                 stateManager.store('languages', null),
                 stateManager.store('language_home_filter', null),
+                stateManager.store('uploaders_auto_filtering', null),
                 stateManager.store('uploaders', null),
                 stateManager.store('uploaders_whitelisted', null),
                 stateManager.store('aggressive_uploaders_filtering', null),

--- a/src/ComicK/ComicKSettings.ts
+++ b/src/ComicK/ComicKSettings.ts
@@ -142,7 +142,7 @@ export const uploadersSettings = (stateManager: SourceStateManager): DUINavigati
                 App.createDUISection({
                     id: 'uploaders_autofiltering',
                     header: 'Autofilter uploaders by score',
-                    footer: 'If enabled, automatically filter uploaders for each chapter\nFor each chapter number, only the uploader with the most upvotes will be displayed.\nIf this is enabled, the below settings will be completely ignored.',
+                    footer: 'If enabled, automatically filter uploaders for each chapter\nFor each chapter number, only the uploader with the most upvotes will be displayed.\nIf this is enabled, the below settings will be disabled.\nDisable this setting to manually manage uploader filtering.',
                     isHidden: false,
                     rows: async () => [
                         App.createDUISwitch({
@@ -158,7 +158,7 @@ export const uploadersSettings = (stateManager: SourceStateManager): DUINavigati
                 App.createDUISection({
                     id: 'modify_uploaders',
                     header: 'Uploaders',
-                    isHidden: false,
+                    isHidden: await getFilterChaptersByScore(stateManager),
                     rows: async () => [
                         App.createDUISelect({
                             id: 'uploaders',
@@ -228,7 +228,7 @@ export const uploadersSettings = (stateManager: SourceStateManager): DUINavigati
                     id: 'select_uploaders',
                     header: 'Filtering Settings',
                     footer: 'Filter Uploaders by name.\nBy default, selected uploaders are excluded from chapter lists (blacklist mode).',
-                    isHidden: false,
+                    isHidden: await getFilterChaptersByScore(stateManager),
                     rows: async () => [
                         App.createDUISwitch({
                             id: 'toggle_uploaders_filtering',


### PR DESCRIPTION
The comick api includes and `up_count` and a `down_count`, this PR uses those values to automatically filter uploaders based on which release for each chapter has a higher "score" (ie `up_count - down_count`).

I am not a JS developer and have zero experience making sources, but I did test this (you can try it from the [pages link](https://tejassharma96.github.io/xonlyfadi-extensions/) in my fork but I encountered some issues since I already had ComicK installed from the main repo, so if you wanna test that way make sure you remove the current version of ComicK) and it worked as expected - more upvotes = you get to show up in the app.