### PR TITLE
Make Vyvymanga work again; add additional cloudflare bypass steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: Bundle and Publish Sources
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     strategy:
       matrix:
@@ -33,7 +35,6 @@ jobs:
         with:
           ref: gh-pages
           path: bundles
-
       - run: npm install
       - run: npm run bundle -- --folder=${{ steps.extract_branch.outputs.branch }}
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@ivanmatthew:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/package.json
+++ b/package.json
@@ -22,11 +22,15 @@
     "@typescript-eslint/parser": "^6.13.1",
     "eslint": "^8.54.0",
     "eslint-plugin-modules-newline": "^0.0.6",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "@paperback/toolchain": "^0.8.0-alpha.47"
+  },
+  "resolutions": {
+    "@paperback/runtime-polyfills": "^0.8.0-alpha.47",
+    "@paperback/types": "^0.8.0-alpha.47"
   },
   "dependencies": {
-    "@paperback/toolchain": "^0.8.0-alpha.47",
-    "@paperback/types": "^0.8.0-alpha.47",
+    "@ivanmatthew/rand-user-agent-cjs": "^2.0.16",
     "cheerio": "^1.0.0-rc.12",
     "crypto-js": "^4.2.0",
     "entities": "^4.4.0",

--- a/src/VyvyManga/VyvyManga.ts
+++ b/src/VyvyManga/VyvyManga.ts
@@ -37,10 +37,10 @@ import {
     UserAgentStore
 } from './VyvyMangaSettings'
 
-const VYVY_DOMAIN = 'https://vyvymanga.net'
+const VYVY_DOMAIN = 'https://vymanga.net'
 
 export const VyvyMangaInfo: SourceInfo = {
-    version: '2.1.0',
+    version: '2.1.1',
     name: 'VyvyManga',
     icon: 'icon.png',
     author: 'xOnlyFadi',

--- a/src/VyvyManga/VyvyMangaSettings.ts
+++ b/src/VyvyManga/VyvyMangaSettings.ts
@@ -1,0 +1,68 @@
+import {
+    DUISection,
+    DUIInputField,
+    SourceStateManager
+} from '@paperback/types'
+
+import { randUA } from '@ivanmatthew/rand-user-agent-cjs/dist/index.js'
+
+// Todo: Seperate?
+// class UserAgentStore {
+//     private static USER_AGENT_STORE_KEY: string = 'custom_user_agent'
+//     private readonly _stateManager: SourceStateManager
+
+//     constructor(stateManager: SourceStateManager) {
+//         this._stateManager = stateManager
+//     }
+
+//     async get(): Promise<string> {
+//         return await this._stateManager.retrieve(UserAgentStore.USER_AGENT_STORE_KEY)
+//     }
+//     async set(userAgent: string): Promise<void> {
+//         return await this._stateManager.store(UserAgentStore.USER_AGENT_STORE_KEY, userAgent)
+//     }
+// }
+export const UserAgentStore = {
+    async get(stateManager: SourceStateManager): Promise<string> {
+        return (await stateManager.retrieve('custom_user_agent') || 'NA')
+    },
+    async set(stateManager: SourceStateManager, userAgent: string): Promise<void> {
+        return await stateManager.store('custom_user_agent', userAgent)
+    }
+}
+
+export const userAgentSettings = (stateManager: SourceStateManager): DUISection => {
+    let someVal = 'NA'
+
+    UserAgentStore.get(stateManager).then((val) => {
+        someVal = val
+    })
+    return App.createDUISection({
+        id: 'cust_ua_sect',
+        footer: 'If you are unable to view content on VyVyManga, consider changing your user agent.',
+        isHidden: false,
+        rows: async () => [
+            App.createDUILabel({
+                id: 'custom_user_agent_if',
+                label: someVal,
+                value: undefined
+            }),
+            App.createDUIButton({
+                id: 'randomize_user_agent',
+                label: 'Randomize User Agent',
+                onTap: async () => {
+                    const newUserAgent = randUA('mobile', 'safari', 'ios')
+                    if (newUserAgent === 'No Agent Found') throw new Error('Failed to generate randomized user agent') // edgecase, shouldn't happen
+                    await UserAgentStore.set(stateManager, newUserAgent)
+                }
+            }),
+            App.createDUIButton({
+                id: 'reset',
+                label: 'Reset to Default',
+                onTap: async () => {
+                    await UserAgentStore.set(stateManager, '')
+                }
+            })
+        ]
+    })
+}


### PR DESCRIPTION
Updated package.json and added VyvyManga settings for user agent customization. Includes randomizer and reset to default.
User agent randomizer is a custom cjs with esm interop compiled from the github registry, hence why the workflow has been modified too.

Update main.yml

Make workflow work

Move env around